### PR TITLE
Update AWS region configuration in application-prod.properties to set…

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -8,7 +8,7 @@ api.key=${API_KEY}
 # AWS Production Configuration
 spring.cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 spring.cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
-spring.cloud.aws.region.static=${AWS_REGION}
+spring.cloud.aws.region.static=${AWS_REGION:us-east-1}
 spring.cloud.aws.region.auto=false
 
 # SQS Configuration


### PR DESCRIPTION
… a default value

- Modified the AWS region property to include a default value of 'us-east-1' if not specified, enhancing flexibility in production settings.